### PR TITLE
Update auth flow with confirmation page

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,8 @@
     import {
       getAuth,
       createUserWithEmailAndPassword,
-      signInWithEmailAndPassword
+      signInWithEmailAndPassword,
+      sendEmailVerification
     } from "https://www.gstatic.com/firebasejs/10.12.1/firebase-auth.js";
 
     const firebaseConfig = {
@@ -70,7 +71,7 @@
               feedback.className = "success";
               feedback.innerText = "Connexion réussie ! Redirection...";
               setTimeout(() => {
-                window.location.href = "https://livewebmonetic.carrd.co";
+                window.location.href = "https://balgha.carrd.co";
               }, 1500);
             } else {
               feedback.className = "error";
@@ -83,12 +84,14 @@
           });
       } else {
         createUserWithEmailAndPassword(auth, email, password)
-          .then(() => {
+          .then((userCredential) => {
             feedback.className = "success";
             feedback.innerText = "Compte créé avec succès ! Redirection...";
-            setTimeout(() => {
-              window.location.href = "https://livewebmonetic.carrd.co";
-            }, 1500);
+            sendEmailVerification(userCredential.user).finally(() => {
+              setTimeout(() => {
+                window.location.href = "verification.html";
+              }, 1500);
+            });
           })
           .catch(err => {
             feedback.className = "error";

--- a/verification.html
+++ b/verification.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Vérification requise</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <p style="text-align:center;">Merci de confirmer votre mail.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `verification.html` page displayed after signup
- send a verification email and redirect to that page
- change post-login redirect to `https://balgha.carrd.co`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888e75584108328b507b2ccb17a8986